### PR TITLE
Fix tree-sitter build

### DIFF
--- a/vendor/tree-sitter-python/bindings/rust/build.rs
+++ b/vendor/tree-sitter-python/bindings/rust/build.rs
@@ -1,28 +1,19 @@
-use std::path::Path;
-extern crate cc;
-
 fn main() {
-    let src_dir = Path::new("src");
+    let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-    c_config.compile("parser");
 
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    cpp_config.compile("scanner");
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 }


### PR DESCRIPTION
Switch to `.c` file (`.cc` doesn't exist) and build as C rather than C++

This is just a copy of https://github.com/tree-sitter/tree-sitter-python/blob/6ecc2b54b39ac390848d81dfcf5ee961f33a2f03/bindings/rust/build.rs