### PR TITLE
Dynamic library for native dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 path = "ffi_ocaml.rs"
 test = false
 doctest = false
-crate-type = ["lib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [[bin]]
 name = "print_ast"

--- a/dune
+++ b/dune
@@ -1,4 +1,3 @@
-
 (env
  (dev
   (flags
@@ -10,14 +9,20 @@
    (:standard -w A-30))
   (ocamlopt_flags (-O3))))
 
+;; generate static and dynamic lib from rust code
 (rule
- (targets libffi_ocaml.a)
- (mode fallback)
- (locks /cargo)
+ (targets libffi_ocaml.a dllffi_ocaml.so)
  (action
-  (progn
-   (run cargo build --release)
-   (run cp ../../target/release/libffi_ocaml.a libffi_ocaml.a))))
+  (no-infer
+   (progn
+    (run cargo build --release)
+    ;; Copy .a
+    (run cp ../../target/release/libffi_ocaml.a libffi_ocaml.a)
+    ;; Copy .so + support macos
+    (with-accepted-exit-codes (or 0 1)
+     (run cp ../../target/release/libffi_ocaml.so dllffi_ocaml.so))
+    (with-accepted-exit-codes (or 0 1)
+     (run cp ../../target/release/libffi_ocaml.dylib dllffi_ocaml.so))))))
 
 (library
  (name errpy)
@@ -28,10 +33,10 @@
   (pps ppx_deriving.show))
  (libraries ocamlpool)
  (c_library_flags -lstdc++ -lpthread)
- (no_dynlink)
  (foreign_archives ffi_ocaml))
 
 (executable
  (name parse_and_print)
+ (modes byte exe)
  (modules parse_and_print)
  (libraries errpy))


### PR DESCRIPTION
Fixes https://github.com/facebook/errpy/issues/4

I'm not sure if this is correct for a multi-target CICD though.

At the moment it just looks into the Rust build output and copies the `.so` or the `.dylib` file depending on what is present.